### PR TITLE
variable to select remote script's shell

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,14 @@
+locals {
+  remote_script_shebang = "#!/usr/bin/env ${var.target_shell}"
+}
+
 resource "null_resource" "kexec_nixos" {
   count = var.kexec_tarball_url == null ? 0 : 1
   connection {
-    type = "ssh"
-    user = var.target_user
-    host = var.target_host
-    port = var.target_port
+    type        = "ssh"
+    user        = var.target_user
+    host        = var.target_host
+    port        = var.target_port
     private_key = var.ssh_private_key
   }
 
@@ -16,6 +20,7 @@ resource "null_resource" "kexec_nixos" {
 
   provisioner "remote-exec" {
     inline = [
+      local.remote_script_shebang,
       "chmod +x /tmp/kexec-nixos.sh",
       "if [[ $(id -u) -ne 0 ]]; then sudo /tmp/kexec-nixos.sh '${var.kexec_tarball_url}'; else /tmp/kexec-nixos.sh '${var.kexec_tarball_url}'; fi"
     ]
@@ -23,7 +28,7 @@ resource "null_resource" "kexec_nixos" {
 
   # Wait for the kexec to become effective.
   provisioner "remote-exec" {
-    inline     = ["sleep 9999"]
+    inline     = [local.remote_script_shebang, "sleep 9999"]
     on_failure = continue
   }
 
@@ -42,9 +47,9 @@ resource "null_resource" "install_nixos" {
   ]
 
   connection {
-    type = "ssh"
-    host = var.target_host
-    port = var.target_port
+    type        = "ssh"
+    host        = var.target_host
+    port        = var.target_port
     private_key = var.ssh_private_key
   }
 
@@ -57,6 +62,7 @@ resource "null_resource" "install_nixos" {
 
   provisioner "remote-exec" {
     inline = [
+      local.remote_script_shebang,
       "set -o errexit",
       "nixos-install --no-root-passwd --no-channel-copy --system /run/nixos-install",
       # Retain ssh host key
@@ -65,17 +71,17 @@ resource "null_resource" "install_nixos" {
   }
 
   provisioner "remote-exec" {
-    inline = concat(["set -o errexit"], var.post_install_commands)
+    inline = concat([local.remote_script_shebang, "set -o errexit"], var.post_install_commands)
   }
 
   # Reboot in the background so we can cleanly finish the script before the hosts go down.
   provisioner "remote-exec" {
-    inline = ["systemd-run --on-active=3 shutdown -r now"]
+    inline = [local.remote_script_shebang, "systemd-run --on-active=3 shutdown -r now"]
   }
 
   # Wait for machine to reboot after installation finishes
   provisioner "remote-exec" {
-    inline     = ["sleep 9999"]
+    inline     = [local.remote_script_shebang, "sleep 9999"]
     on_failure = continue
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "target_port" {
   default     = 22
 }
 
+variable "target_shell" {
+  type        = string
+  description = "The shell name to run remote scripts"
+  default     = "bash"
+}
+
 variable "ssh_private_key" {
   type        = string
   description = "Content of private key used to connect to the target_host"


### PR DESCRIPTION
OVH's debian image defines `dash` as default shell (`/bin/sh`) when called by terraform remote-exec.

`[[ ... ]]` is not POSIX-compliant, hence execution is failing with:

```
/tmp/terraform_1313681740.sh: 3: [[: not found
```

An alternative would be to rewrite the condition using `[ ... ]` but as `kexec-nixos.sh` requires `bash` anyway, it sounds reasonable to require it also for terraform.